### PR TITLE
Feat/ping command

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ miss.
 | `/mute` | Mute a user | `/mute <user> <duration> <reason>` | ✅ | 
 | `/unmute` | Unmute a user | `/unmute <user>` | ❌ |
 | `/clear` | Clear a number of messages | `/clear <number>` | ❌ |
+| `/moovemessages` | Move messages from one channel to another | `/moovemessages <source-channel> <target-channel> <number>` | ❌ |
 | `/setmuterole` | Set the mute role | `/setmuterole <role>` | 🔄 |
 
 ### Members
@@ -118,9 +119,9 @@ miss.
 
 | Command | Description | Usage | implemented |
 | --- | --- | --- | --- |
-| `/help` | Display the help message | `/help` | ❌ |
-| `/ping` | Display the bot ping | `/ping` | ❌ |
-| `/invite` | Display the bot invite link | `/invite` | ❌ |
+| `/help` | Display the help message | `/help` | 🔄 |
+| `/ping` | Display the bot ping | `/ping` | ✅ |
+| `/invite` | Display the bot invite link | `/invite` | 🔄 |
 | `/stats` | Display the bot stats | `/stats` | ❌ |
 | `/quote` | Display a random quote from Ahri | `/quote` | ✅ |
 

--- a/src/main/java/com/paulrezzonico/Main.kt
+++ b/src/main/java/com/paulrezzonico/Main.kt
@@ -6,12 +6,12 @@ import io.mongock.runner.springboot.EnableMongock
 import com.paulrezzonico.command.admin.MuteCommand
 import com.paulrezzonico.command.ahri.quote.RandomQuoteCommand
 import com.paulrezzonico.command.casual.pat.PatCommand
+import com.paulrezzonico.command.information.PingCommand
 import net.dv8tion.jda.api.JDA
 import net.dv8tion.jda.api.JDABuilder
 import net.dv8tion.jda.api.interactions.commands.OptionType
 import net.dv8tion.jda.api.interactions.commands.build.Commands
 import net.dv8tion.jda.api.requests.GatewayIntent
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.SpringApplication
 import org.springframework.boot.autoconfigure.SpringBootApplication
@@ -22,24 +22,16 @@ import org.springframework.scheduling.annotation.EnableScheduling
 @SpringBootApplication
 @EnableScheduling
 @Suppress("SpreadOperator", "MemberNameEqualsClassName")
-open class Main {
+open class Main(
+    private val randomQuoteCommand: RandomQuoteCommand,
+    private val patCommand: PatCommand,
+    private val muteCommand: MuteCommand,
+    private val kickCommand: KickCommand,
+    private val banCommand: BanCommand,
+    private val pingCommand: PingCommand,
+) {
     @Value("\${discord.bot.token}")
     private val token: String? = null
-
-    @Autowired
-    private val randomQuoteCommand: RandomQuoteCommand? = null
-
-    @Autowired
-    private val patCommand: PatCommand? = null
-
-    @Autowired
-    private val muteCommand: MuteCommand? = null
-
-    @Autowired
-    private val kickCommand: KickCommand? = null
-
-    @Autowired
-    private val banCommand: BanCommand? = null
 
     @Bean
     @Throws(Exception::class)
@@ -52,6 +44,7 @@ open class Main {
                 muteCommand,
                 kickCommand,
                 banCommand,
+                pingCommand,
             )
             .build()
             .awaitReady()
@@ -73,7 +66,8 @@ open class Main {
             Commands.slash("ban", "Ban a user")
                 .addOption(OptionType.USER, "user", "The user to ban", true)
                 .addOption(OptionType.STRING, "reason", "The reason for the ban", false)
-                .addOption(OptionType.INTEGER, "deletion-days", "Number of days of messages to delete (0-7)", false)
+                .addOption(OptionType.INTEGER, "deletion-days", "Number of days of messages to delete (0-7)", false),
+            Commands.slash("ping", "Check the bot's latency"),
         ).queue()
     }
 

--- a/src/main/java/com/paulrezzonico/command/information/PingCommand.kt
+++ b/src/main/java/com/paulrezzonico/command/information/PingCommand.kt
@@ -1,0 +1,15 @@
+package com.paulrezzonico.command.information
+
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent
+import net.dv8tion.jda.api.hooks.ListenerAdapter
+import org.springframework.stereotype.Component
+
+@Component
+class PingCommand : ListenerAdapter() {
+    override fun onSlashCommandInteraction(event: SlashCommandInteractionEvent) {
+        if (event.name == "ping") {
+            val ping = event.jda.gatewayPing
+            event.reply("Pong! 🏓\nLatency: ${ping}ms").queue()
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces several changes to enhance bot functionality and improve code structure. The most significant updates include adding a new `/ping` command to check bot latency, refactoring the `Main` class to use constructor injection for dependencies, and updating the `README.md` to reflect the implementation status of commands.

### New Command Implementation:
* Added the `/ping` command to check the bot's latency, implemented in a new `PingCommand` class. (`src/main/java/com/paulrezzonico/command/information/PingCommand.kt`)
* Registered the `/ping` command in the bot's command list. (`src/main/java/com/paulrezzonico/Main.kt`)

### Code Refactoring:
* Refactored the `Main` class to use constructor injection for dependencies (`RandomQuoteCommand`, `PatCommand`, `MuteCommand`, `KickCommand`, `BanCommand`, and `PingCommand`) instead of field injection via `@Autowired`. (`src/main/java/com/paulrezzonico/Main.kt`)

### Documentation Updates:
* Updated the `README.md` to mark `/ping` as implemented and `/help` and `/invite` as partially implemented. Also added `/moovemessages` to the list of commands. (`README.md`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R64) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L121-R124)